### PR TITLE
Refactored CryptoFactory with map and separated controller components

### DIFF
--- a/src/AppComponent.hpp
+++ b/src/AppComponent.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "oatpp/parser/json/mapping/ObjectMapper.hpp"
-
 #include "oatpp/web/server/HttpConnectionHandler.hpp"
 #include "oatpp/network/tcp/server/ConnectionProvider.hpp"
 
@@ -35,12 +33,4 @@ public:
 		OATPP_COMPONENT(std::shared_ptr<oatpp::web::server::HttpRouter>, router); // get Router component
 		return oatpp::web::server::HttpConnectionHandler::createShared(router);
 		}());
-
-	/**
-	 *  Create ObjectMapper component to serialize/deserialize DTOs in Contoller's API
-	 */
-	OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::data::mapping::ObjectMapper>, apiObjectMapper)([] {
-		return oatpp::parser::json::mapping::ObjectMapper::createShared();
-		}());
-
 };

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1,6 +1,8 @@
+
 #include "AppComponent.hpp"
-#include "controller/MyController.hpp"
+#include "controller/ControllerComponent.hpp"
 #include "controller/CryptoController.hpp"
+#include "controller/MyController.hpp"
 
 #include "oatpp/network/Server.hpp"
 
@@ -8,15 +10,14 @@
 static void run() {
 
     /* Register Components in scope of run() method */
-    AppComponent components;
+    AppComponent appComponents;
+    ControllerComponent controllerComponents;
 
     /* Get router component */
     OATPP_COMPONENT(std::shared_ptr<oatpp::web::server::HttpRouter>, router);
 
     /* Create MyController and add all of its endpoints to router */
-    auto myController = std::make_shared<MyController>();
-    router->addController(myController);
-
+    router->addController(std::make_shared<MyController>());
     router->addController(std::make_shared<CryptoController>());
 
     /* Get connection handler component */
@@ -47,5 +48,4 @@ int main() {
     oatpp::base::Environment::destroy();
 
     return 0;
-
 }

--- a/src/controller/ControllerComponent.hpp
+++ b/src/controller/ControllerComponent.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "oatpp/core/macro/component.hpp"
+#include "oatpp/parser/json/mapping/ObjectMapper.hpp"
+
+#include "service/crypto/CryptoFactory.hpp"
+
+/**
+ *  Class which creates and holds Controller components and registers components in oatpp::base::Environment
+ *  Order of components initialization is from top to bottom
+ */
+class ControllerComponent {
+public:
+	/**
+	 *  Create ObjectMapper component to serialize/deserialize DTOs in Contoller's API
+	 */
+	OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::data::mapping::ObjectMapper>, apiObjectMapper)([] {
+		return oatpp::parser::json::mapping::ObjectMapper::createShared();
+		}());
+	/**
+	 *  Create Crypto Factory component
+	 */
+	OATPP_CREATE_COMPONENT(std::shared_ptr<CryptoFactory>, cryptoFactory)([] {
+		return std::make_shared<CryptoFactory>();
+		}());
+
+};

--- a/src/controller/CryptoController.hpp
+++ b/src/controller/CryptoController.hpp
@@ -1,13 +1,11 @@
 #pragma once
 
-#include "magic_enum.hpp"
-
 #include "oatpp/web/server/api/ApiController.hpp"
 #include "oatpp/core/macro/codegen.hpp"
 #include "oatpp/core/macro/component.hpp"
 
+#include "controller/ControllerComponent.hpp"
 #include "dto/CryptoDTO.hpp"
-#include "service/crypto/CryptoFactory.hpp"
 
 #include OATPP_CODEGEN_BEGIN(ApiController) ///< Begin Codegen
 
@@ -17,7 +15,7 @@ public:
 	 * Constructor with object mapper.
 	 * @param objectMapper - default object mapper used to serialize/deserialize DTOs.
 	 */
-	CryptoController(OATPP_COMPONENT(std::shared_ptr<ObjectMapper>, objectMapper))
+	CryptoController(OATPP_COMPONENT(std::shared_ptr<oatpp::data::mapping::ObjectMapper>, objectMapper))
 		: oatpp::web::server::api::ApiController(objectMapper)
 	{}
 public:
@@ -31,24 +29,28 @@ public:
 			"Received request with algorithm='%s', key='%d', and text='%s'",
 			algorithm->c_str(), static_cast<int>(key), text->c_str());
 
-		auto dto = CryptoDto::createShared();
-		dto->statusCode = 200;
-		dto->key = key;
-		dto->algorithm = algorithm;
+		OATPP_COMPONENT(std::shared_ptr<CryptoFactory>, cryptoFactory);
 
-		auto crypto = CryptoFactory::GetCrypto
-		(
-			magic_enum::enum_cast<CryptoAlgo>
-			(
-				algorithm->c_str(),
-				magic_enum::case_insensitive
-			).value_or(CryptoAlgo::IDENTITY),
-			key
-		);
+		auto crypto = cryptoFactory->GetCrypto(algorithm, key);
 
-		dto->text = crypto->Encrypt(text);
-
-		return createDtoResponse(Status::CODE_200, dto);
+		if (crypto)
+		{
+			auto dto = CryptoDto::createShared();
+			dto->statusCode = 200;
+			dto->key = key;
+			dto->algorithm = algorithm;
+			dto->text = crypto->Encrypt(text);
+			return createDtoResponse(Status::CODE_200, dto);
+		}
+		else
+		{
+			auto dto = CryptoDto::createShared();
+			dto->statusCode = 400;
+			dto->key = key;
+			dto->algorithm = algorithm;
+			dto->text = "Algorithm implementation not found!";
+			return createDtoResponse(Status::CODE_400, dto);
+		}
 	}
 
 	ENDPOINT("GET", "/decrypt", decrypt,
@@ -60,24 +62,28 @@ public:
 			"Received request with algorithm='%s', key='%d', and text='%s'",
 			algorithm->c_str(), static_cast<int>(key), text->c_str());
 
-		auto dto = CryptoDto::createShared();
-		dto->statusCode = 200;
-		dto->key = key;
-		dto->algorithm = algorithm;
+		OATPP_COMPONENT(std::shared_ptr<CryptoFactory>, cryptoFactory);
 
-		auto crypto = CryptoFactory::GetCrypto
-		(
-			magic_enum::enum_cast<CryptoAlgo>
-			(
-				algorithm->c_str(),
-				magic_enum::case_insensitive
-			).value_or(CryptoAlgo::IDENTITY),
-			key
-		);
+		auto crypto = cryptoFactory->GetCrypto(algorithm, key);
 
-		dto->text = crypto->Decrypt(text);
-
-		return createDtoResponse(Status::CODE_200, dto);
+		if (crypto)
+		{
+			auto dto = CryptoDto::createShared();
+			dto->statusCode = 200;
+			dto->key = key;
+			dto->algorithm = algorithm;
+			dto->text = crypto->Decrypt(text);
+			return createDtoResponse(Status::CODE_200, dto);
+		}
+		else
+		{
+			auto dto = CryptoDto::createShared();
+			dto->statusCode = 400;
+			dto->key = key;
+			dto->algorithm = algorithm;
+			dto->text = "Algorithm implementation not found!";
+			return createDtoResponse(Status::CODE_400, dto);
+		}
 	}
 
 };

--- a/src/controller/MyController.hpp
+++ b/src/controller/MyController.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "dto/MessageDTO.hpp"
-
 #include "oatpp/web/server/api/ApiController.hpp"
 #include "oatpp/core/macro/codegen.hpp"
 #include "oatpp/core/macro/component.hpp"
+
+#include "controller/ControllerComponent.hpp"
+#include "dto/MessageDTO.hpp"
 
 #include OATPP_CODEGEN_BEGIN(ApiController) ///< Begin Codegen
 
@@ -28,9 +29,6 @@ public:
         dto->message = "Hello World!";
         return createDtoResponse(Status::CODE_200, dto);
     }
-
-    // TODO Insert Your endpoints here !!!
-
 };
 
 #include OATPP_CODEGEN_END(ApiController) ///< End Codegen

--- a/src/service/crypto/CryptoFactory.cpp
+++ b/src/service/crypto/CryptoFactory.cpp
@@ -1,20 +1,34 @@
 #include "CryptoFactory.hpp"
 
+#include "magic_enum.hpp"
 #include "service/crypto/CaesarCipher.hpp"
 #include "service/crypto/XorCipher.hpp"
 #include "service/crypto/IdentityCipher.hpp"
 
+CryptoFactory::CryptoFactory()
+	: m_CryptoMap{
+		{CryptoAlgo::CAESAR,	[](int key) {return std::make_shared<CaesarCipher>(key); }},
+		{CryptoAlgo::XOR,		[](int key) {return std::make_shared<XorCipher>(key); }},
+		{CryptoAlgo::IDENTITY,	[](int key) {return std::make_shared<IdentityCipher>(key); }},
+	}
+{ }
+
 std::shared_ptr<Crypto> CryptoFactory::GetCrypto(CryptoAlgo algo, int key)
 {
-	switch (algo)
+	return m_CryptoMap[algo](key);
+}
+
+std::shared_ptr<Crypto> CryptoFactory::GetCrypto(const std::string& algo, int key)
+{
+	return GetCrypto(std::string_view{ algo }, key);
+}
+
+std::shared_ptr<Crypto> CryptoFactory::GetCrypto(std::string_view algo, int key)
+{
+	auto algoEnum = magic_enum::enum_cast<CryptoAlgo>(algo, magic_enum::case_insensitive);
+	if (algoEnum.has_value())
 	{
-	case CryptoAlgo::CAESAR:
-		return std::make_shared<CaesarCipher>(key);
-	case CryptoAlgo::XOR:
-		return std::make_shared<XorCipher>(key);
-	case CryptoAlgo::IDENTITY:
-		return std::make_shared<IdentityCipher>(key);
-	default:
-		return std::make_shared<IdentityCipher>(key);
+		return GetCrypto(algoEnum.value(), key);
 	}
+	else return nullptr;
 }

--- a/src/service/crypto/CryptoFactory.hpp
+++ b/src/service/crypto/CryptoFactory.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <functional>
 #include <memory>
+#include <string_view>
+#include <unordered_map>
 
 #include "Crypto.hpp"
 
@@ -12,7 +15,11 @@ enum class CryptoAlgo
 class CryptoFactory
 {
 private:
-	CryptoFactory() = delete;
+	using MapReturn_t = std::function<std::shared_ptr<Crypto>(int)>;
+	std::unordered_map<CryptoAlgo, MapReturn_t> m_CryptoMap;
 public:
-	static std::shared_ptr<Crypto> GetCrypto(CryptoAlgo algo, int key = 5);
+	CryptoFactory();
+	std::shared_ptr<Crypto> GetCrypto(CryptoAlgo algo, int key = 5);
+	std::shared_ptr<Crypto> GetCrypto(const std::string& algo, int key = 5);
+	std::shared_ptr<Crypto> GetCrypto(std::string_view algo, int key = 5);
 };


### PR DESCRIPTION
- Utilized unordered map for item creation in the CryptoFactory
- Moved conversion logic to/from string and similar types to CryptoAlgo enum inside CryptoFactory
- Separated the logic of components used by controllers and moved them into a relevant file
- Added logic for missing algorithm request in the CryptoController